### PR TITLE
Perform data indexing and computations on-demand when required

### DIFF
--- a/app/scripts/index.js
+++ b/app/scripts/index.js
@@ -27,6 +27,9 @@ class App {
     this.visualization.addEventListener("pointHovered", (event) =>
       console.log("pointHovered", event)
     );
+    this.visualization.addEventListener("pointClicked", (event) =>
+      console.log("pointClicked", event)
+    );
     this.visualization.addEventListener("pan", (event) =>
       console.log("pan", event)
     );
@@ -46,7 +49,7 @@ class App {
 
     let selem = document.getElementById("specification-select");
     selem.value = "tsne-10th";
-    selem.dispatchEvent(new Event('change'));
+    selem.dispatchEvent(new Event("change"));
 
     document.getElementById("refresh-specification").click();
   }

--- a/cypress/integration/data-processor.spec.js
+++ b/cypress/integration/data-processor.spec.js
@@ -188,7 +188,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([1, 1, 7, 7]);
         expect(allPoints).to.have.lengthOf(
@@ -215,7 +216,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([1, 1, 7, 7]);
         expect(allPoints).to.have.lengthOf(
@@ -261,7 +263,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([1, 1, 7, 7]);
         expect(allPoints).to.have.lengthOf(
@@ -297,7 +300,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([1, 1, 7, 7]);
         expect(allPoints).to.have.lengthOf(
@@ -331,7 +335,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([1, 1, 7, 7]);
         expect(allPoints).to.have.lengthOf(
@@ -367,7 +372,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([
           testGenomeScale.toClipSpaceFromString("chr1:1"),
@@ -446,7 +452,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([
           testGenomeScale.toClipSpaceFromString("chr1:1"),
@@ -525,7 +532,8 @@ describe("Box selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         const allPoints = dataProcessor.selectBox([
           testGenomeScale.toClipSpaceFromString("chr1:1"),
@@ -612,7 +620,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([1, 1, 2, 1, 3, 2, 2, 2.5])
@@ -626,7 +635,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([1, 1, 2, 1, 3, 2, 2, 2.5])
@@ -640,7 +650,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([1, 1, 2, 1, 3, 2, 2, 2.5])
@@ -654,7 +665,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([1, 1, 2, 1, 3, 2, 2, 2.5])
@@ -668,7 +680,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([1, 1, 2, 1, 3, 2, 2, 2.5])
@@ -682,7 +695,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([
@@ -709,7 +723,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([
@@ -736,7 +751,8 @@ describe("Lasso selection", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         expect(
           dataProcessor.selectLasso([
@@ -768,7 +784,8 @@ describe("Get closest point", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         let closest = dataProcessor.getClosestPoint([1.1, 1.1]).closestPoint;
         expect(closest.category).to.eq("a");
@@ -789,7 +806,8 @@ describe("Get closest point", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         let closest = dataProcessor.getClosestPoint([1, 1]);
         expect(closest.closestPoint.category).to.eq("a");
@@ -817,7 +835,8 @@ describe("Get closest point", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         let closest = dataProcessor.getClosestPoint([1.1, 1.1]);
         expect(closest.closestPoint.category).to.eq("a");
@@ -845,7 +864,8 @@ describe("Get closest point", () => {
     );
 
     cy.wrap(dataProcessor)
-      .should("have.property", "index")
+      .should("have.property", "specificationHelper")
+      .then(() => dataProcessor.indexDataIfNotAlreadyIndexed())
       .then(() => {
         let closest = dataProcessor.getClosestPoint([
           testGenomeScale.toClipSpaceFromString("chr1:101"),

--- a/src/epiviz.gl/data-processor.js
+++ b/src/epiviz.gl/data-processor.js
@@ -17,7 +17,10 @@ class DataProcessor {
 
     console.log("Loading data...");
 
-    new SpecificationProcessor(specification, this.indexData.bind(this));
+    new SpecificationProcessor(
+      specification,
+      this.specificationCallback.bind(this)
+    );
   }
 
   /**
@@ -25,7 +28,20 @@ class DataProcessor {
    *
    * @param {SpecificationProcessor} specificationHelper that is built in the constructor
    */
-  indexData(specificationHelper) {
+
+  specificationCallback(specificationHelper) {
+    this.specificationHelper = specificationHelper;
+  }
+
+  /**
+   * Indexes the data in the specificationHelper and stores it in the data and index fields of the DataProcessor
+   * object.
+   */
+  indexDataIfNotAlreadyIndexed() {
+    // If the data has already been indexed or specificationHelper hasn't been built yet, do nothing
+    if (this.index || !this.specificationHelper) return;
+    // Otherwise, index the data
+    const specificationHelper = this.specificationHelper;
     let totalPoints = 0;
 
     for (const track of specificationHelper.tracks) {
@@ -114,15 +130,14 @@ class DataProcessor {
    * @returns closest point or undefined
    */
   getClosestPoint(point) {
-    let indices = this.index.neighbors(point[0], point[1], 1, 0)
-    let pointToReturn =
-      this.data[indices];
+    let indices = this.index.neighbors(point[0], point[1], 1, 0);
+    let pointToReturn = this.data[indices];
     let distance = 0;
     let isInside = true;
     if (pointToReturn === undefined) {
-      indices = this.index.neighbors(point[0], point[1], 1, 5)
-      if(indices.length === 0) {
-        indices = this.index.neighbors(point[0], point[1], 1)
+      indices = this.index.neighbors(point[0], point[1], 1, 5);
+      if (indices.length === 0) {
+        indices = this.index.neighbors(point[0], point[1], 1);
       }
       pointToReturn = this.data[indices];
       distance = Math.sqrt(
@@ -146,12 +161,11 @@ class DataProcessor {
     const largerX = Math.max(points[0], points[2]);
     const largerY = Math.max(points[1], points[3]);
 
-    let indices = this.index
-      .search(smallerX, smallerY, largerX, largerY)
-    
-    let tpoints =  indices.map((i) => this.data[i]);
+    let indices = this.index.search(smallerX, smallerY, largerX, largerY);
 
-    return {indices, "points": tpoints};
+    let tpoints = indices.map((i) => this.data[i]);
+
+    return { indices, points: tpoints };
   }
 
   /**
@@ -199,12 +213,12 @@ class DataProcessor {
         simplifiedBoundingPolygon
       );
 
-      if (tbool) findices.push(candidatePoints.indices[i])
+      if (tbool) findices.push(candidatePoints.indices[i]);
 
       return tbool;
     });
 
-    return {"indices": findices, "points": fpoints}
+    return { indices: findices, points: fpoints };
   }
 }
 

--- a/src/epiviz.gl/utilities.js
+++ b/src/epiviz.gl/utilities.js
@@ -264,6 +264,10 @@ const getQuadraticBezierCurveForPoints = (P0, P1, P2) => {
   return (t) => [x(t), y(t)];
 };
 
+const POINT_HOVERED_EVENT_NAME = "pointHovered";
+const POINT_CLICKED_EVENT_NAME = "pointClicked";
+const ON_SELECTION_END_EVENT_NAME = "onSelectionEnd";
+
 export {
   scale,
   rgbToHex,
@@ -275,4 +279,7 @@ export {
   getQuadraticBezierCurveForPoints,
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
+  ON_SELECTION_END_EVENT_NAME,
+  POINT_HOVERED_EVENT_NAME,
+  POINT_CLICKED_EVENT_NAME,
 };

--- a/src/epiviz.gl/webgl-vis.js
+++ b/src/epiviz.gl/webgl-vis.js
@@ -234,7 +234,7 @@ class WebGLVis {
    */
   selectPoints(points) {
     // Only send the points if there is a listener for it
-    if (this.eventListentersMap.get(ON_SELECTION_START_EVENT_NAME)) {
+    if (this.eventListentersMap.get(ON_SELECTION_END_EVENT_NAME)) {
       if (points.length === 4) {
         this.dataWorker.postMessage({ type: "selectBox", points });
       } else if (points.length >= 6) {


### PR DESCRIPTION
While working on on-demand indexing, I noticed that the library was unnecessarily performing complex computations on the data and searching for points in the index, even when the application using the library was not actively listening to events like 'pointHovered', 'pointClicked', or 'selectionEnd'. This led to wasted resources and decreased performance.

In this PR, I have optimized the library by ensuring that data indexing and computation are performed only when required by the application. The indexing process now begins the first time a function that depends on indexing is called, and the indexed data is then reused for subsequent calls. This approach eliminates unnecessary computation and indexing, resulting in improved efficiency and performance.