### PR TITLE
Support for Typed Arrays in JSON Validator

### DIFF
--- a/cypress/integration/specification-validation.spec.js
+++ b/cypress/integration/specification-validation.spec.js
@@ -527,9 +527,21 @@ describe("Visualization Specification Validation", function () {
       tracks: [baseValidTrack, baseValidTrack],
     };
 
+    const baseValidVisualizationWithTypedArrays = {
+      defaultData: {
+        attr1: new Float32Array([1, 2, 3, 4]),
+        attr2: new Uint32Array([1, 2, 3, 4]),
+      },
+      tracks: [baseValidTrack, baseValidTrack],
+    };
+
     it("can require tracks property", function () {
       expect(isJSONValid(baseValidVisualization)).to.eq(true);
       expect(isJSONValid({})).to.eq(false);
+    });
+
+    it("should validate if defaultData has typed arrays", function () {
+      expect(isJSONValid(baseValidVisualizationWithTypedArrays)).to.eq(true);
     });
 
     it("can reject if a track is not valid", function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.gl",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "repository": "https://github.com/epiviz/epiviz.gl",
   "homepage": "https://github.com/epiviz/epiviz.gl",
   "author": {


### PR DESCRIPTION
This pull request includes improvements to the JSON validator, enhancing its ability to correctly handle TypedArray instances in the defaultData property of the input JSON.

Previously, the validator was not adequately handling TypedArray instances, leading to potential validation failures or undesirable formats when such arrays were present. This update modifies the isJSONValid utility function in the JSON schema validator script to check for the existence of any TypedArray instances in the defaultData property. If such instances are found, a deep copy of the entire JSON object is created, where all TypedArray instances are correctly converted into standard JavaScript arrays.

This update ensures that validation will correctly handle all TypedArray variants, namely: Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array, BigInt64Array, and BigUint64Array.

Also updated the tests and added a test to validate typed arrays.