### PR TITLE
Added an event that is dispatched when user clicks on labels.

### DIFF
--- a/app/scripts/index.js
+++ b/app/scripts/index.js
@@ -27,6 +27,9 @@ class App {
     this.visualization.addEventListener("pointHovered", (event) =>
       console.log("pointHovered", event)
     );
+    this.visualization.addEventListener("labelClicked", (event) =>
+      console.log("labelClicked", event)
+    );
     this.visualization.addEventListener("pan", (event) =>
       console.log("pan", event)
     );

--- a/src/epiviz.gl/mouse-reader.js
+++ b/src/epiviz.gl/mouse-reader.js
@@ -42,7 +42,8 @@ class MouseReader {
 
     // Initializing elements to show user their current selection
     this.SVGInteractor = new SVGInteractor(
-      document.createElementNS("http://www.w3.org/2000/svg", "svg")
+      document.createElementNS("http://www.w3.org/2000/svg", "svg"),
+      handler.dispatchEvent.bind(handler, "labelClicked")
     );
   }
 

--- a/src/epiviz.gl/svg-interactor.js
+++ b/src/epiviz.gl/svg-interactor.js
@@ -15,7 +15,8 @@ class SVGInteractor {
    *
    * @param {SVGElement} svg container for all svg elements
    */
-  constructor(svg) {
+  constructor(svg, labelClickHandler) {
+    this.labelClickHandler = labelClickHandler;
     this.svg = svg;
     this.d3SVG = select(this.svg);
     this.svg.style.width = "100%";
@@ -52,6 +53,7 @@ class SVGInteractor {
     this.svg.style.width = styles.width;
     this.svg.style.height = styles.height;
     this.svg.style.margin = styles.margin;
+    this.svg.style.cursor = "default"; // or "none"
 
     this.initialX = undefined; // used for updating labels
     this.initialY = undefined;
@@ -129,10 +131,28 @@ class SVGInteractor {
       );
     }
 
-    select(this._labelMarker)
+    const labels = select(this._labelMarker)
       .selectAll("text")
-      .data(this.specification.labels)
+      .data(this.specification.labels);
+    labels
+      .enter()
+      .append("text")
+      .merge(labels) // Updates both existing and new nodes
       .text((d) => d.text)
+      .attr("style", "pointer-events: bounding-box") // Add this line to make the labels respond to pointer events
+      .style("user-select", "none") // add this line
+      .on("click", (event, d) => {
+        const clickedIndex = select(this._labelMarker)
+          .selectAll("text")
+          .nodes()
+          .indexOf(event.currentTarget);
+
+        this.labelClickHandler({
+          label: d.text,
+          index: clickedIndex,
+          labelObject: d,
+        });
+      })
       .attr("x", (d, i) => {
         if (d.fixedX) {
           return this.initialX[i];
@@ -154,6 +174,9 @@ class SVGInteractor {
           select(this).attr(property, d[property]);
         }
       });
+
+    // Remove any old labels
+    labels.exit().remove();
   }
 
   _calculateAxis(dimension, orientation, specification, genomeScale, anchor) {

--- a/src/epiviz.gl/webgl-vis.js
+++ b/src/epiviz.gl/webgl-vis.js
@@ -108,25 +108,18 @@ class WebGLVis {
         if (message.data.closestPoint === undefined) {
           return;
         }
-        this.parent.dispatchEvent(
-          new CustomEvent("pointHovered", { detail: message })
-        );
+        this.dispatchEvent("pointHovered", message);
       } else if (message.data.type === "getClickPoint") {
         if (message.data.closestPoint === undefined) {
           return;
         }
-        this.parent.dispatchEvent(
-          new CustomEvent("pointClicked", { detail: message })
-        );
+        this.dispatchEvent("pointClicked", message);
       } else if (
         message.data.type === "selectBox" ||
         message.data.type === "selectLasso"
       ) {
-        this.parent.dispatchEvent(
-          new CustomEvent("onSelectionEnd", { detail: message })
-        );
+        this.dispatchEvent("onSelectionEnd", message);
         this.dataWorkerStream.push(message);
-        console.log(this.dataWorkerStream);
       }
     };
     this.dataWorker.onerror = (e) => {
@@ -134,7 +127,7 @@ class WebGLVis {
     };
 
     // Needs to be called at the end of addToDOM so mouseReader has correct dimensions to work with
-    this.mouseReader.init();
+    this.mouseReader.init(this.parent);
   }
 
   /**
@@ -291,6 +284,8 @@ class WebGLVis {
    * "onSelection": fires while user is changing the selection box/lasso
    * "onSelectionEnd": fires when a selection has been completed and the results are in the dataWorkerStream
    * "pointHovered": fires when pointer hovers over a datapoint
+   * "pointClicked": fires when pointer clicks on a datapoint
+   * "labelClicked": fires when pointer clicks on a label
    *
    * For information on the parameters and functionality see:
    *   https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
@@ -301,6 +296,16 @@ class WebGLVis {
    */
   addEventListener(type, listener, options) {
     this.parent.addEventListener(type, listener, options);
+  }
+
+  /**
+   * Dispatches an event on the visualization on the appropriate component.
+   * @param {String} eventName
+   * @param {Object} message
+   **/
+  dispatchEvent(eventName, message) {
+    const event = new CustomEvent(eventName, { detail: message });
+    this.parent.dispatchEvent(event);
   }
 
   /**


### PR DESCRIPTION
In this pull request, I've introduced a new functionality in the epiviz.gl library that allows dispatching of events when a label is clicked on a heatmap.

Previously, the library lacked a built-in method for detecting clicks on labels and reacting to these interactions. With this update, users can now tap into an event listener that will trigger whenever a row or column label is clicked.

This feature was designed with extensibility in mind, paving the way for further enhancements such as custom callbacks or other interactivity features tied to label clicks. This functionality is particularly useful in implementing selection and highlighting features in the parent applications using the epiviz.gl library.

The new event dispatch on label click is integral to the improved highlight functionality for multiple rows and columns in heatmaps that I've developed in a separate pull request. It is important to apply this update to epiviz.gl to fully benefit from the enhancements to heatmap interactivity.