### PR TITLE
Improve labels svg group by removing out-of-bounds labels

### DIFF
--- a/src/epiviz.gl/svg-interactor.js
+++ b/src/epiviz.gl/svg-interactor.js
@@ -129,21 +129,47 @@ class SVGInteractor {
       );
     }
 
-    select(this._labelMarker)
+    const labels = select(this._labelMarker)
       .selectAll("text")
-      .data(this.specification.labels)
+      .data(this.specification.labels);
+    labels
+      .enter()
+      .append("text")
+      .merge(labels) // Updates both existing and new nodes
       .text((d) => d.text)
-      .attr("x", (d, i) => {
+      .attr("x", (d, i, nodes) => {
+        const svgNode = this.d3SVG.node();
+        const rect = svgNode.getBoundingClientRect();
+        const width = rect.width;
+
         if (d.fixedX) {
           return this.initialX[i];
         }
-        return this._calculateViewportSpotInverse(d.x, d.y)[0];
+
+        const xPos = this._calculateViewportSpotInverse(d.x, d.y)[0];
+
+        if (xPos < 0 || xPos > width) {
+          select(nodes[i]).remove();
+        } else {
+          return xPos;
+        }
       })
-      .attr("y", (d, i) => {
+      .attr("y", (d, i, nodes) => {
+        const svgNode = this.d3SVG.node();
+        const rect = svgNode.getBoundingClientRect();
+        const height = rect.height;
+
         if (d.fixedY) {
           return this.initialY[i];
         }
-        return this._calculateViewportSpotInverse(d.x, d.y)[1];
+
+        const yPos = this._calculateViewportSpotInverse(d.x, d.y)[1];
+
+        if (yPos < 0 || yPos > height) {
+          select(nodes[i]).remove();
+        } else {
+          return yPos;
+        }
       })
       .each(function (d) {
         // Set any possible svg properties specified in label
@@ -154,6 +180,9 @@ class SVGInteractor {
           select(this).attr(property, d[property]);
         }
       });
+
+    // Remove any old labels
+    labels.exit().remove();
   }
 
   _calculateAxis(dimension, orientation, specification, genomeScale, anchor) {


### PR DESCRIPTION
This PR addresses an issue in our visualization where labels were overflowing on each other by being out of the SVG viewport. By removing these out-of-bound labels, we significantly enhance the readability and clarity of our visualization.