### PR TITLE
Removed z-index + updated hover events to include group node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.gl",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "repository": "https://github.com/epiviz/epiviz.gl",
   "homepage": "https://github.com/epiviz/epiviz.gl",
   "author": {

--- a/src/epiviz.gl/svg-interactor.js
+++ b/src/epiviz.gl/svg-interactor.js
@@ -29,7 +29,6 @@ class SVGInteractor {
     this.svg.style.width = "100%";
     this.svg.style.height = "100%";
     this.svg.style.position = "absolute";
-    this.svg.style.zIndex = "1000";
     this.svg.style.pointerEvents = "none";
     this.svg.style.overflow = "visible";
 
@@ -171,6 +170,7 @@ class SVGInteractor {
           label: d.text,
           index: hoveredIndex,
           labelObject: d,
+          groupNode: this._labelMarker,
           event,
         });
       })
@@ -184,6 +184,7 @@ class SVGInteractor {
           label: d.text,
           index: hoveredIndex,
           labelObject: d,
+          groupNode: this._labelMarker,
           event,
         });
       })


### PR DESCRIPTION
Z-Index was too much popping up over other items in the application it was being used, Removed it fixes the issue.

Also added group node in hover events for future uses incase for relative positioning, I need the node to calculate tooltip position inside epiviz.heatmap.gl.