### PR TITLE
Add Optional Uni-Directional Selection Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ All visualizations also include an ability to box or lasso select:
 
 ![selection](./docs/images/selection.gif)
 
+### Unidirectional Selection:
+
+`epiviz.gl` supports unidirectional selection in the plot which allows the selection to occur only horizontally or vertically depending upon the major axis of the movement. This feature is disabled by default. It can be enabled or disabled using the `setUniDirectionSelectEnabled` function as shown below:
+
+```javascript
+plot.setUniDirectionSelectEnabled(true); // enables unidirectional selection
+plot.setUniDirectionSelectEnabled(false); // disables unidirectional selection
+```
+
+By setting the argument to true, the unidirectional selection will be enabled. Setting it to false will disable this feature.
+
 # Specifications
 
 Documentation for specifications can be found in [docs/specification_doc.md](https://github.com/epiviz/epiviz.gl/blob/main/docs/specification_doc.md). Documentation for the specifications can be generated with [json-schema-for-humans](https://pypi.org/project/json-schema-for-humans/):

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All visualizations also include an ability to box or lasso select:
 
 ### Unidirectional Selection:
 
-`epiviz.gl` supports unidirectional selection in the plot which allows the selection to occur only horizontally or vertically depending upon the major axis of the movement. This enhances the feature of box selection by allowing the user to select a region in a single direction. This feature is only available for box selection and not for lasso selection. It is disabled by default. It can be enabled or disabled using the `setViewOptions` function as shown below:
+For box-selections, `epiviz.gl` supports unidirectional selection in the plot, which restricts the selection to occur either horizontally or vertically based on mouse movement. This enhances box selection by allowing the user to select a region in a single direction. It is disabled by default and can be enabled by using the `setViewOptions` function.
 
 ```javascript
 plot.setViewOptions({

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All visualizations also include an ability to box or lasso select:
 
 ### Unidirectional Selection:
 
-`epiviz.gl` supports unidirectional selection in the plot which allows the selection to occur only horizontally or vertically depending upon the major axis of the movement. This feature is disabled by default. It can be enabled or disabled using the `setUniDirectionSelectEnabled` function as shown below:
+`epiviz.gl` supports unidirectional selection in the plot which allows the selection to occur only horizontally or vertically depending upon the major axis of the movement. This enhances the feature of box selection by allowing the user to select a region in a single direction. This feature is only available for box selection and not for lasso selection. It is disabled by default. It can be enabled or disabled using the `setUniDirectionSelectEnabled` function as shown below:
 
 ```javascript
 plot.setUniDirectionSelectEnabled(true); // enables unidirectional selection

--- a/README.md
+++ b/README.md
@@ -68,11 +68,15 @@ All visualizations also include an ability to box or lasso select:
 
 ### Unidirectional Selection:
 
-`epiviz.gl` supports unidirectional selection in the plot which allows the selection to occur only horizontally or vertically depending upon the major axis of the movement. This enhances the feature of box selection by allowing the user to select a region in a single direction. This feature is only available for box selection and not for lasso selection. It is disabled by default. It can be enabled or disabled using the `setUniDirectionSelectEnabled` function as shown below:
+`epiviz.gl` supports unidirectional selection in the plot which allows the selection to occur only horizontally or vertically depending upon the major axis of the movement. This enhances the feature of box selection by allowing the user to select a region in a single direction. This feature is only available for box selection and not for lasso selection. It is disabled by default. It can be enabled or disabled using the `setViewOptions` function as shown below:
 
 ```javascript
-plot.setUniDirectionSelectEnabled(true); // enables unidirectional selection
-plot.setUniDirectionSelectEnabled(false); // disables unidirectional selection
+plot.setViewOptions({
+  uniDirectionalSelectionEnabled: true,
+}); // enables unidirectional selection
+plot.setViewOptions({
+  uniDirectionalSelectionEnabled: false,
+}); // disables unidirectional selection
 ```
 
 By setting the argument to true, the unidirectional selection will be enabled. Setting it to false will disable this feature.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.gl",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "repository": "https://github.com/epiviz/epiviz.gl",
   "homepage": "https://github.com/epiviz/epiviz.gl",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.gl",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "repository": "https://github.com/epiviz/epiviz.gl",
   "homepage": "https://github.com/epiviz/epiviz.gl",
   "author": {

--- a/src/epiviz.gl/mouse-reader.js
+++ b/src/epiviz.gl/mouse-reader.js
@@ -53,6 +53,7 @@ class MouseReader {
       handler.dispatchEvent.bind(handler, "labelHovered"),
       handler.dispatchEvent.bind(handler, "labelUnhovered")
     );
+    this.uniDirectionalSelectionEnabled = true;
   }
 
   /**
@@ -162,14 +163,18 @@ class MouseReader {
               this.selectStartPoint.y - this.selectEndPoint.y
             );
 
-            if (diffX <= SELECT_THRESHOLD && diffY > SELECT_THRESHOLD) {
+            if (this.lockedX) {
+              this.tool = "boxv";
+            } else if (this.lockedY) {
+              this.tool = "boxh";
+            } else if (diffX <= SELECT_THRESHOLD && diffY > SELECT_THRESHOLD) {
               this.tool = "boxv";
             } else if (diffY <= SELECT_THRESHOLD && diffX > SELECT_THRESHOLD) {
               this.tool = "boxh";
             } else {
               this.tool = "box";
             }
-            if (this.uniDirectionalSelectionEnabled) {
+            if (this.isUniDirectionalSelectionAllowed) {
               this.handler.dispatchEvent("onSelection", {
                 bounds: getPointsBySelectMode(
                   this.tool,
@@ -411,7 +416,7 @@ class MouseReader {
     let selectionPoints = this._currentSelectionPoints;
 
     if (
-      this.uniDirectionalSelectionEnabled &&
+      this.isUniDirectionalSelectionAllowed &&
       (this.tool === "box" || this.tool === "boxh" || this.tool === "boxv")
     ) {
       selectionPoints = getPointsBySelectMode(
@@ -431,7 +436,7 @@ class MouseReader {
    * @param {MouseEvent} event from the event it is called from
    */
   _onSelect(event) {
-    if (this.tool === "box" && this.uniDirectionalSelectionEnabled) {
+    if (this.tool === "box" && this.isUniDirectionalSelectionAllowed) {
       this.handler.selectPoints(
         getPointsBySelectMode(
           this.tool,
@@ -464,6 +469,10 @@ class MouseReader {
   clear() {
     this._currentSelectionPoints = [];
     this.SVGInteractor.clear();
+  }
+
+  get isUniDirectionalSelectionAllowed() {
+    return this.uniDirectionalSelectionEnabled || this.lockedX || this.lockedY;
   }
 }
 

--- a/src/epiviz.gl/mouse-reader.js
+++ b/src/epiviz.gl/mouse-reader.js
@@ -169,7 +169,7 @@ class MouseReader {
             } else {
               this.tool = "box";
             }
-            if (this.handler.uniDirectionSelectionEnabled) {
+            if (this.uniDirectionalSelectionEnabled) {
               this.handler.dispatchEvent("onSelection", {
                 bounds: getPointsBySelectMode(
                   this.tool,
@@ -411,7 +411,7 @@ class MouseReader {
     let selectionPoints = this._currentSelectionPoints;
 
     if (
-      this.handler.uniDirectionSelectionEnabled &&
+      this.uniDirectionalSelectionEnabled &&
       (this.tool === "box" || this.tool === "boxh" || this.tool === "boxv")
     ) {
       selectionPoints = getPointsBySelectMode(
@@ -431,7 +431,7 @@ class MouseReader {
    * @param {MouseEvent} event from the event it is called from
    */
   _onSelect(event) {
-    if (this.tool === "box" && this.handler.uniDirectionSelectionEnabled) {
+    if (this.tool === "box" && this.uniDirectionalSelectionEnabled) {
       this.handler.selectPoints(
         getPointsBySelectMode(
           this.tool,

--- a/src/epiviz.gl/utilities.js
+++ b/src/epiviz.gl/utilities.js
@@ -296,15 +296,14 @@ const cloneMouseEvent = (e) => {
   };
 };
 
-
 const getPointsBySelectMode = (selectMode, originalPoints, xRange, yRange) => {
   const points = [...originalPoints];
   switch (selectMode) {
-    case "horizontal":
+    case "boxh":
       points[1] = yRange[0];
       points[3] = yRange[1];
       break;
-    case "vertical":
+    case "boxv":
       points[0] = xRange[0];
       points[2] = xRange[1];
       break;

--- a/src/epiviz.gl/utilities.js
+++ b/src/epiviz.gl/utilities.js
@@ -264,10 +264,27 @@ const getQuadraticBezierCurveForPoints = (P0, P1, P2) => {
   return (t) => [x(t), y(t)];
 };
 
+
+const getPointsBySelectMode = (selectMode, originalPoints, xRange, yRange) => {
+  const points = [...originalPoints];
+  switch (selectMode) {
+    case "horizontal":
+      points[1] = yRange[0];
+      points[3] = yRange[1];
+      break;
+    case "vertical":
+      points[0] = xRange[0];
+      points[2] = xRange[1];
+      break;
+  }
+  return points;
+};
+
 export {
   scale,
   rgbToHex,
   rgbStringToHex,
+  getPointsBySelectMode,
   getViewportForSpecification,
   colorSpecifierToHex,
   getScaleForSpecification,

--- a/src/epiviz.gl/webgl-vis.js
+++ b/src/epiviz.gl/webgl-vis.js
@@ -24,8 +24,6 @@ class WebGLVis {
     this.canvas = document.createElement("canvas");
     this.canvas.style.position = "absolute";
 
-    this.uniDirectionSelectionEnabled = false;
-
     this.POSSIBLE_MOUSE_READER_OPTIONS = Object.freeze([
       "lockedX",
       "lockedY",
@@ -33,6 +31,7 @@ class WebGLVis {
       "viewport",
       "currentXRange",
       "currentYRange",
+      "uniDirectionalSelectionEnabled",
     ]);
   }
 
@@ -54,17 +53,6 @@ class WebGLVis {
     this.mouseReader.width = width;
     this.mouseReader.height = height;
     this.sendDrawerState(this.mouseReader.getViewport());
-  }
-
-  /**
-   * Set the flag for uniDirectionSelectEnabled to be used by the mouse reader
-   * to determine whether user is allowed to do horizontal or vertical selection
-   * @param {Boolean} enabled whether or not to enable uniDirectionSelect
-   * @memberof WebGLVis
-   * @returns {void}
-   */
-  setUniDirectionSelectEnabled(enabled) {
-    this.uniDirectionSelectionEnabled = enabled;
   }
 
   /**
@@ -153,6 +141,7 @@ class WebGLVis {
    *   viewport: [minX, maxX, minY, maxY] (all Numbers)
    *   currentXRange: [x1, x2] (Numbers that should be within the viewport minX and maxX)
    *   currentYRange: [y1, y2] (Numbers that should be within the viewport minY and maxY)
+   *   uniDirectionalSelectionEnabled: boolean
    *   tool: one of ["pan", "box", "lasso"]
    *
    * @param {Object} options with keys under WebGLVis.POSSIBLE_MOUSE_READER_OPTIONS

--- a/src/epiviz.gl/webgl-vis.js
+++ b/src/epiviz.gl/webgl-vis.js
@@ -24,6 +24,8 @@ class WebGLVis {
     this.canvas = document.createElement("canvas");
     this.canvas.style.position = "absolute";
 
+    this.uniDirectionSelectionEnabled = false;
+
     this.POSSIBLE_MOUSE_READER_OPTIONS = Object.freeze([
       "lockedX",
       "lockedY",
@@ -52,6 +54,17 @@ class WebGLVis {
     this.mouseReader.width = width;
     this.mouseReader.height = height;
     this.sendDrawerState(this.mouseReader.getViewport());
+  }
+
+  /**
+   * Set the flag for uniDirectionSelectEnabled to be used by the mouse reader
+   * to determine whether user is allowed to do horizontal or vertical selection
+   * @param {Boolean} enabled whether or not to enable uniDirectionSelect
+   * @memberof WebGLVis
+   * @returns {void}
+   */
+  setUniDirectionSelectEnabled(enabled) {
+    this.uniDirectionSelectionEnabled = enabled;
   }
 
   /**


### PR DESCRIPTION
This PR introduces an optional feature that enables uni-directional (vertical or horizontal) or box selection on the plots.

By default, the feature is disabled. Users who wish to use this selection interaction can enable it by calling plot.setUniDirectionSelectEnabled(true). This flexibility allows users to opt into the functionality only when needed.

The feature works with a default threshold distance of 30px in the viewport. It behaves as an invisible '+' sign around the initial click point: if the mouse movement stays within that range, it will be interpreted as either a vertical or horizontal selection. If the movement exceeds the threshold, it will result in a box select.

One important note is that this may require users to zoom in for precise box selections within the 30px range, as the viewport needs to be expanded to accurately capture the selection.