### PR TITLE
Fixed Unidirection Coordinates Bug

### DIFF
--- a/src/epiviz.gl/mouse-reader.js
+++ b/src/epiviz.gl/mouse-reader.js
@@ -455,7 +455,10 @@ class MouseReader {
    * @param {MouseEvent} event from the event it is called from
    */
   _onSelect(event) {
-    if (this.tool === "box" && this.isUniDirectionalSelectionAllowed) {
+    if (
+      (this.tool === "box" || this.tool === "boxh" || this.tool === "boxv") &&
+      this.isUniDirectionalSelectionAllowed
+    ) {
       this.handler.selectPoints(
         getPointsBySelectMode(
           this.tool,


### PR DESCRIPTION
When user does unidirectional select, it shows the correct selected area, but in on select event it was not emitting correct coordinates.

It is fixed now.