### PR TITLE
Added ability to customize svg options and fixed svg overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,33 @@ setViewOptions({
 });
 ```
 
+### SVG Options
+
+You can now specify the SVG options for the visualization using the `setSVGOptions` function. Default value is
+
+```javascript
+{
+  svgStyle: {
+    width: "100%",
+    height: "100%",
+    position: "absolute",
+    pointerEvents: "none",
+    overflow: "visible",
+  },
+  selectionMarkerAttributes: {
+    fill: "rgba(124, 124, 247, 0.3)",
+    stroke: "rgb(136, 128, 247)",
+    "stroke-width": "1",
+    "stroke-dasharray": "5,5",
+  },
+}
+```
+
+It supports the following options:
+
+- `svgStyle`: An object containing the style attributes for the SVG element.
+- `selectionMarkerAttributes`: An object containing the style attributes for the selection marker.
+
 ### Zoom Control Direction
 
 You can now specify to use natural scrolling or inverted scrolling for zooming in and out using the `setViewOptions` function. Default value is `true`.
@@ -451,3 +478,7 @@ const exampleMap = new Map([
 If your example is particularly long to render due to many vertices or a large amount of data, consider adding it to the [`longPresets`](https://github.com/epiviz/epiviz.gl/blob/main/cypress/support/index.js#:~:text=const-,longPresets,-%3D%20%5B%22tsne%22%2C%20%22tsne-10th) array.
 
 6. If you completed step 5, rerecord the tests, but be sure to **only commit only the test-image from your example (provided it is correct)**.
+
+```
+
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epiviz.gl",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "repository": "https://github.com/epiviz/epiviz.gl",
   "homepage": "https://github.com/epiviz/epiviz.gl",
   "author": {

--- a/src/epiviz.gl/mouse-reader.js
+++ b/src/epiviz.gl/mouse-reader.js
@@ -75,6 +75,10 @@ class MouseReader {
     this._updateSVG();
   }
 
+  setSVGOptions(options) {
+    this.SVGInteractor.setOptions(options);
+  }
+
   /**
    * Set the viewport in the format mouseReader.viewport = [minX, maxX, minY, maxY].
    * Mostly used to make WebGLVis.setViewOptions simpler.

--- a/src/epiviz.gl/webgl-vis.js
+++ b/src/epiviz.gl/webgl-vis.js
@@ -158,6 +158,30 @@ class WebGLVis {
     this.sendDrawerState(this.mouseReader.getViewport());
   }
 
+  /**
+   * Set the options for the SVG overlay.
+   * @param {Object} options
+   * @param {String} options.selectionAttributes - CSS attributes for the selection box
+   *
+   * @example
+   * setSVGOptions({
+   *  svgStyle: {
+   *    position: "absolute",
+   *  },
+   *  selectionMarkerAttributes: {
+   *    fill: "none",
+   *    stroke: "black",
+   *    "stroke-width": "2",
+   *    "stroke-dasharray": "5,5"
+   *  }
+   * });
+   *
+   **/
+
+  setSVGOptions(options) {
+    this.mouseReader.setSVGOptions(options);
+  }
+
   _setMargins(specification) {
     const styles = getDimAndMarginStyleForSpecification(specification);
     this.parent.style.width = specification.width || DEFAULT_WIDTH;


### PR DESCRIPTION
This PR addresses two things

1. Support for svg customization
2. A bugfix for svg marker where svg is drawn beyond the canvas boundary over the labels.

# Details about svg customization

You can now specify the SVG options for the visualization using the `setSVGOptions` function. Default value is

```javascript
{
  svgStyle: {
    width: "100%",
    height: "100%",
    position: "absolute",
    pointerEvents: "none",
    overflow: "visible",
  },
  selectionMarkerAttributes: {
    fill: "rgba(124, 124, 247, 0.3)",
    stroke: "rgb(136, 128, 247)",
    "stroke-width": "1",
    "stroke-dasharray": "5,5",
  },
}
```

It supports the following options:

- `svgStyle`: An object containing the style attributes for the SVG element.
- `selectionMarkerAttributes`: An object containing the style attributes for the selection marker.